### PR TITLE
Adds a case with ALWAYS_TRUE operator

### DIFF
--- a/tests/current/enabled.yaml
+++ b/tests/current/enabled.yaml
@@ -22,6 +22,14 @@ tests:
         expected:
           value: false
 
+      - name: returns the correct value for a simple flag with ALWAYS_TRUE operator
+        client: feature_flag_client
+        function: enabled
+        input:
+          flag: "flag.always_true"
+        expected:
+          value: true
+
       #####################
       ## PROP_IS_ONE_OF ##
       #####################


### PR DESCRIPTION
This adds a case for `flag.always_true` which uses the ALWAYS_TRUE operator